### PR TITLE
Fix bug in printf.c: Unable to print consecutive specifiers

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -29,7 +29,8 @@ int _printf(const char *format, ...)
 			if (print_ptr)
 			{
 				count = count + print_ptr(print_obj);
-				i = i + 2;
+				i = i + 1;
+				continue;
 			}
 			else if (check_for_some_chars(next) == 1)
 				return (-1);


### PR DESCRIPTION
printf was unable to print properly when two or more valid specifiers are placed next to each other. This Fix solves it